### PR TITLE
Incorporate safer/more flexible URL handling in TeamCity plugin

### DIFF
--- a/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/ApplyPatch.java
+++ b/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/ApplyPatch.java
@@ -32,7 +32,7 @@ public class ApplyPatch extends Task {
         this.gitClient = new GitClient(this.appConfig.getWorkingDir());
         this.arcanistClient = new ArcanistClient(
                 this.appConfig.getConduitToken(), this.appConfig.getWorkingDir(), this.appConfig.getArcPath());
-        this.conduitClient = new ConduitClient(this.appConfig.getPhabricatorUrl(), this.appConfig.getConduitToken());
+        this.conduitClient = new ConduitClient(this.appConfig.getPhabricatorUrl().toString(), this.appConfig.getConduitToken());
     }
 
     @Override

--- a/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
+++ b/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
@@ -10,6 +10,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
+import java.net.URL;
+
 /**
  * Created by mjo20 on 10/31/2015.
  */
@@ -35,10 +37,12 @@ public class HarbormasterBuildStatus extends Task {
     @Override
     protected void setup() {
         try {
+            URL phabricatorURL = this.appConfig.getPhabricatorUrl();
             this.httpPost = (HttpPost) new HttpRequestBuilder()
                     .post()
-                    .setScheme("http")
-                    .setHost(this.appConfig.getPhabricatorUrl())
+                    .setScheme(phabricatorURL.getProtocol())
+                    .setHost(phabricatorURL.getHost())
+                    .setPort(phabricatorURL.getPort())
                     .setPath("/api/harbormaster.sendmessage")
                     .addFormParam(new StringKeyValue("api.token", this.appConfig.getConduitToken()))
                     .addFormParam(new StringKeyValue("type", parseTeamCityBuildStatus(this.buildFinishedStatus)))


### PR DESCRIPTION
For cases in which a Phabricator installation runs on a custom port or doesn't support plain HTTP, this plugin is currently limited. This modifies the phabricatorUrl in the AppConfig to be a URL rather than a String, which makes the TeamCity build feature configuration more flexible. I've built and tested this change within my local CI environment.